### PR TITLE
Increase postgres shared memory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: cvat_db
     image: postgres:15-alpine
     restart: always
+    shm_size: 1g
     environment:
       POSTGRES_USER: root
       POSTGRES_DB: cvat


### PR DESCRIPTION
CVAT returning 500 Server Error on loading tasks. Found this error in cvat_db container:

`2023-08-24 15:48:51.484 UTC [534377] ERROR:  could not resize shared memory segment "/PostgreSQL.290604002" to 16777216 bytes: No space left on device`

Attempted solution from here: https://stackoverflow.com/questions/56751565/pq-could-not-resize-shared-memory-segment-no-space-left-on-device